### PR TITLE
license was missing in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,14 @@
     "npm"
   ],
   "author": "Marvin Schieler",
+  "contributors": [
+    "Marco Sadowski <marco@camefrom.space>"
+  ],
   "license": "LGPL-3.0",
   "bin": {
     "uglify-merge": "./cli.js"
   },
+  "license": "LGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/arsors/uglify-merge-js/issues"
   },


### PR DESCRIPTION
causing that yarn/npm warns that there is no license:
```
$ yarn global add uglify-merge-js
yarn global v1.12.3
warning package.json: No license field
```